### PR TITLE
Revamp navigation and portfolio sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,28 +12,38 @@
       <h1>Chimdumebi Nebolisa</h1>
       <nav class="site-nav">
         <ul>
+          <li><a href="#home">Home</a></li>
+          <li><a href="#about">About Me</a></li>
           <li><a href="#projects">Projects</a></li>
-          <li><a href="#certifications">Certifications</a></li>
-          <li><a href="#publications">Publications</a></li>
         </ul>
       </nav>
     </div>
   </header>
 
   <main class="container">
-    <section id="projects" class="card">
+    <section id="home" class="card hero">
+      <h2>Welcome</h2>
+      <p class="hero-name">Chimdumebi Nebolisa</p>
+      <p class="hero-tagline">Computer science student, aspiring product builder, and community advocate.</p>
+    </section>
+
+    <section id="about" class="card about">
+      <h2>About Me</h2>
+      <p>
+        I am a computer science student at Boise State University who is passionate about using technology to create accessible, human-centered solutions. I enjoy working at the intersection of product design, data, and engineering to craft experiences that solve real problems and empower the people who use them.
+      </p>
+      <p>
+        My professional journey has included leading research and product initiatives focused on accessibility, mentoring students who are curious about technology, and collaborating across disciplines to ship thoughtful solutions. I thrive in environments where I can combine creativity with analytical thinking, and I am always eager to learn new tools that help teams deliver meaningful products.
+      </p>
+      <p>
+        Beyond the classroom and workplace, I dedicate time to community-building efforts that champion diversity in tech. Whether I am facilitating workshops, organizing events, or contributing to open-source projects, I aim to uplift others and make technology more inclusive.
+      </p>
+    </section>
+
+    <section id="projects" class="card projects">
       <h2>Projects</h2>
-      <p>Highlight key projects here. Describe your role, the tech stack, and the impact of each project.</p>
-    </section>
-
-    <section id="certifications" class="card">
-      <h2>Certifications</h2>
-      <p>List professional certifications, courses, or training that showcase your expertise.</p>
-    </section>
-
-    <section id="publications" class="card">
-      <h2>Publications</h2>
-      <p>Share academic papers, articles, talks, or other public-facing work you’ve authored.</p>
+      <p>Explore selected projects that highlight my work across software development, research, and community impact.</p>
+      <div class="project-grid"></div>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- update the navigation to link to Home, About Me, and Projects sections
- replace the main content with hero, detailed about, and projects sections
- remove the certifications and publications content while keeping anchors consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8679b50e083289e55b3d00f2b3039