### PR TITLE
Maintain single-column layout across breakpoints

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -75,7 +75,8 @@ a {
 
 main {
   padding: 3rem 0;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 2rem;
 }
 
@@ -111,11 +112,7 @@ main {
   font-size: 0.95rem;
 }
 
-@media (min-width: 768px) {
-  main {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
+/* Maintain a single-column layout across viewport sizes */
 
 @media (prefers-reduced-motion: reduce) {
   * {


### PR DESCRIPTION
## Summary
- update the main element to use a vertical flex layout so sections stay stacked
- remove the large-screen grid media query so the single-column layout persists across viewport sizes

## Testing
- Viewed the page in a 1400px-wide browser

------
https://chatgpt.com/codex/tasks/task_e_68d869540d008328b57a52523a62fb18